### PR TITLE
validate llm model, bugfix for make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build: ## Build Kuzco
 	env $(if $(GOOS),GOOS=$(GOOS)) $(if $(GOARCH),GOARCH=$(GOARCH)) $(GO) build -o build/$(BINARY_NAME) -ldflags "-X 'github.com/RoseSecurity/kuzco/cmd.Version=local'" main.go
 
 install: ## Install dependencies
-	$(GO) install ./...@latest
+	$(GO) install ./...
 
 clean: ## Clean up build artifacts
 	$(GO) clean

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,12 @@ func runAnalyzer(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	// Validate that the specified model exists in Ollama
+	if err := internal.ValidateModel(model, addr); err != nil {
+		fmt.Fprintf(os.Stderr, "Model validation error: %v\n", err)
+		os.Exit(1)
+	}
+
 	// Proceed with the main logic if all required flags are set
 	if err := internal.Run(filePath, model, addr); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)


### PR DESCRIPTION
## Why

- it's hard to remember which models are downloaded, available
- it's hard (for me) to remember how to spell models or to remember which ones I may have recently switched to
- it's sometimes challenging to know if my awesome terraform is so excellent that there are no recommendations, vs when I just typoed the model name; I'd like clear feedback when I screw up the model name. 

## What

- allows `make install` to work on macOS with GNU Make 3.81, asdf shimmed go environment
- validates model against known local llm models available
 
## References

- closes #3
- closes #4