### PR TITLE
feat: add publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish Packages
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      # Run GoReleaser to build the Debian package
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          args: release --rm-dist
+
+      - name: Get Debian package name
+        id: deb_package
+        run: echo "PACKAGE=$(find dist/ -name '*.deb')" >> $GITHUB_ENV
+
+      # Push the Debian package to Cloudsmith
+      - name: Push Debian package to Cloudsmith
+        id: push
+        uses: cloudsmith-io/action@master
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: "push"
+          format: "deb"
+          owner: "rosesecurity"
+          repo: "kuzco"
+          distro: "any-distro"
+          version: "any-version"
+          file: ${{ env.PACKAGE }}
+


### PR DESCRIPTION
## Why

- Make it easier to publish and push packages to Cloudsmith for distribution