### PR TITLE
feat: add dry run command for homebrew distribution

### DIFF
--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/RoseSecurity/kuzco/internal"
 	u "github.com/RoseSecurity/kuzco/pkg/utils"
 	"github.com/spf13/cobra"
@@ -19,9 +22,24 @@ func init() {
 	recommendCmd.Flags().StringVarP(&model, "model", "m", "llama3.2", "LLM model to use for generating recommendations")
 	recommendCmd.Flags().StringVarP(&prompt, "prompt", "p", "", "User prompt for guiding the response format of the LLM model")
 	recommendCmd.Flags().StringVarP(&addr, "address", "a", "http://localhost:11434", "IP Address and port to use for the LLM model (ex: http://localhost:11434)")
+	recommendCmd.Flags().BoolVar(&dryrun, "dry-run", false, "Test unused parameter functionality")
+	// Hide dry run flag
+	recommendCmd.Flags().Lookup("dry-run").Hidden = true
 }
 
 func Analyze(cmd *cobra.Command, args []string) {
+	// Run the logic test if the flag is set
+	if dryrun {
+		var unusedAttrs []string
+		unusedAttrs, err := internal.DryRun(filePath, tool)
+		if err != nil {
+			u.LogErrorAndExit(err)
+		} else {
+			fmt.Println("Unused attributes:", unusedAttrs)
+		}
+		os.Exit(0)
+	}
+
 	// Validate that the specified model exists in Ollama
 	if err := internal.ValidateModel(model, addr); err != nil {
 		u.LogErrorAndExit(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ var (
 	model    string
 	prompt   string
 	addr     string
+	dryrun   bool
 )
 
 var rootCmd = &cobra.Command{

--- a/internal/dry_run.go
+++ b/internal/dry_run.go
@@ -1,0 +1,74 @@
+package internal
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// DryRun checks the provided file for unused attributes based on a provider schema.
+func DryRun(filePath, tool string) ([]string, error) {
+	if !(strings.HasSuffix(filePath, ".tf") || strings.HasSuffix(filePath, ".tofu")) {
+		return nil, fmt.Errorf("the provided file must have a .tf or .tofu extension")
+	}
+
+	resources, err := ParseConfigurationFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing configuration file: %v", err)
+	}
+
+	// Placeholder schema, which would typically be loaded based on the provider type
+	var providerSchema ProviderSchema
+	dir := filepath.Dir(filePath) // Ensure `dir` is correctly derived
+
+	switch tool {
+	case "terraform":
+		providerSchema, err = ExtractTerraformProviderSchema(dir)
+		if err != nil {
+			return nil, fmt.Errorf("error extracting Terraform provider schema: %v", err)
+		}
+	case "opentofu":
+		providerSchema, err = ExtractOpenTofuProviderSchema(dir)
+		if err != nil {
+			return nil, fmt.Errorf("error extracting OpenTofu provider schema: %v", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported tool: %s. Supported tools are 'terraform' and 'opentofu'", tool)
+	}
+
+	// Identify and return unused attributes
+	unusedAttrs, err := testPossibleAttributes(resources, providerSchema, tool)
+	if err != nil {
+		return nil, fmt.Errorf("error identifying unused attributes: %v", err)
+	}
+
+	return unusedAttrs, nil
+}
+
+// testPossibleAttributes checks each resource for unused attributes and returns them.
+func testPossibleAttributes(resources []Resource, schema ProviderSchema, tool string) ([]string, error) {
+	var unusedAttrs []string
+	for _, resource := range resources {
+		if possibleAttrs, ok := schema.ResourceTypes[resource.Type]; ok {
+			usedAttrs := resource.Attributes
+			unusedAttrsForResource := testFindUnusedAttributes(usedAttrs, possibleAttrs)
+
+			// Collect unused attributes
+			unusedAttrs = append(unusedAttrs, unusedAttrsForResource...)
+		} else {
+			fmt.Printf("No schema found for resource type %s. Skipping unused attribute check.\n", resource.Type)
+		}
+	}
+	return unusedAttrs, nil
+}
+
+// testFindUnusedAttributes identifies unused attributes by comparing used and possible attributes.
+func testFindUnusedAttributes(usedAttrs map[string]string, possibleAttrs map[string]interface{}) []string {
+	var unusedAttrs []string
+	for attr := range possibleAttrs {
+		if _, used := usedAttrs[attr]; !used {
+			unusedAttrs = append(unusedAttrs, attr)
+		}
+	}
+	return unusedAttrs
+}


### PR DESCRIPTION
## What and Why

- The goal is to distribute this tooling using Homebrew. We need to provide a better testing framework to assess the tool works before pushing to the community

---

- Incorporates a `--dry-run` flag for testing configurations