### PR TITLE
feat: add homebrew installation and workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,3 +70,15 @@ jobs:
           release: "any-version"
           file: ${{ env.AMD_PACKAGE }}
 
+  homebrew:
+    name: "Bump Homebrew Formula"
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
+          formula-name: kuzco
+          formula-path: Formula/k/kuzco.rb
+        env:
+          COMMITTER_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Here's the **problem**: You spin up a Terraform or OpenTofu resource, pull a bas
 > [!NOTE]
 > To use `kuzco`, Ollama must be installed. You can do this by running `brew bundle install` or `brew install ollama`. For more information on customizing Ollama models for tailored Kuzco responses, check out [Customizing Ollama](./docs/Customizing_Ollama.md)
 
+### Homebrew
+
+```sh
+brew install kuzco
+```
+
 ### Go
 
 If you have a functional Go environment, you can install with:


### PR DESCRIPTION
## What and Why

- Make the distribution of Kuzco easier for Mac users by incorporating `brew install kuzco`