### PR TITLE
refactor(attributes): improve unused attribute detection

### DIFF
--- a/internal/llm.go
+++ b/internal/llm.go
@@ -61,7 +61,7 @@ Example output:
 resource "type" "name" {
   # Enables feature X for improved security
   attribute1 = value1
-  
+
   # Optimizes performance by setting Y
   attribute2 = value2
 }`, tool, resourceType, unusedAttrs)
@@ -74,7 +74,7 @@ Example output:
 resource "type" "name" {
   # Enables feature X for improved security
   attribute1 = value1
-  
+
   # Optimizes performance by setting Y
   attribute2 = value2
 }`, tool, resourceType, unusedAttrs, prompt)


### PR DESCRIPTION
This pull request refines how unused resource attributes are detected and parsed in the codebase. The main changes ensure that only valid attribute and block type names are considered when checking for unused attributes, and parsing is made more robust by not requiring schema evaluation for attribute detection.

**Unused attribute detection logic improvements:**

* Updated `findUnusedAttributes` in `internal/analyzer.go` to only consider attribute names found under `block.attributes` and `block.block_types`, ensuring more accurate unused attribute detection.
* Mirrored this logic in `testFindUnusedAttributes` in `internal/dry_run.go` for consistency between analyzer and test runs.

**Parsing robustness:**

* Modified resource parsing in `internal/parser.go` to use `JustAttributes`, allowing collection of all attribute keys without requiring schema or evaluating expressions, and improved error handling for attribute reading.

**Minor cleanup:**

* Removed unnecessary blank line in `internal/dry_run.go` for readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - More precise detection of unused attributes by considering only valid block attributes and nested block types.
  - Parser now collects attribute names and issues warnings on attribute diagnostics instead of failing, improving resilience.
  - Dry-run output reflects the refined unused-attribute logic for clearer reports.
  - Minor formatting tweak to generated prompts (no functional impact).

- Bug Fixes
  - Reduced false positives in unused attribute reporting, aligning results with actual block-level definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->