### PR TITLE
feat: add Claude Code CLI support as LLM backend

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,43 +1,36 @@
-run:
-  deadline: 5m
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    #- bodyclose
-    # - deadcode ! deprecated since v1.49.0; replaced by 'unused'
-    #- depguard
-    #- dogsled
-    #- dupl
     - errcheck
-    #- exhaustive
-    #- funlen
-    #- gochecknoinits
     - goconst
     - gocritic
-    #- gocyclo
-    - gofmt
-    - goimports
-    #- gomnd
-    #- goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
-    #- lll
     - misspell
-    #- nakedret
-    #- noctx
     - nolintlint
-    #- rowserrcheck
-    #- scopelint
     - staticcheck
-    #- structcheck ! deprecated since v1.49.0; replaced by 'unused'
-    - stylecheck
-    #- typecheck
     - unconvert
-    #- unparam
     - unused
-    # - varcheck ! deprecated since v1.49.0; replaced by 'unused'
-    #- whitespace
-  fast: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -34,10 +34,17 @@ func Diagnose(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	// Validate that the specified model exists in Ollama
-	if err := internal.ValidateModel(model, addr); err != nil {
-		fmt.Fprintf(os.Stderr, "Model validation error: %v\n", err)
-		os.Exit(1)
+	// Validate that the specified model exists
+	if internal.IsClaudeModel(model) {
+		if err := internal.ValidateClaudeModel(model); err != nil {
+			fmt.Fprintf(os.Stderr, "Model validation error: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		if err := internal.ValidateOllamaModel(model, addr); err != nil {
+			fmt.Fprintf(os.Stderr, "Model validation error: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	// Read the configuration file content
@@ -70,15 +77,15 @@ Example Corrected Configuration:
 resource "type" "name" {
   # Explanation of attribute1's purpose
   attribute1 = "value1"
-  
+
   # Optional comment for attribute2
   attribute2 = "value2"
 }
 
 Please review and update the configuration file as outlined above to resolve the issue.`, filePath, config)
 
-	// Pass the prompt and file content to GetRecommendations
-	recommendations, err := internal.GetRecommendations(string(config), nil, model, tool, prompt, addr)
+	// Pass the prompt to the appropriate LLM backend
+	recommendations, err := internal.GetFix(prompt, model, addr)
 	if err != nil {
 		u.LogErrorAndExit(err)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -10,8 +10,8 @@ import (
 // listCmd commands lists models
 var listCmd = &cobra.Command{
 	Use:                "list",
-	Short:              "Lists available Ollama models",
-	Long:               `Queries and lists available Ollama models for Kuzco use`,
+	Short:              "Lists available LLM models",
+	Long:               `Queries and lists available LLM models for Kuzco use`,
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 }
 

--- a/cmd/list_models.go
+++ b/cmd/list_models.go
@@ -13,15 +13,15 @@ import (
 	u "github.com/RoseSecurity/kuzco/pkg/utils"
 )
 
-// ListModelsCmd lists Ollama models
-var listModelsCmd = &cobra.Command{
+// ListOllamaModelsCmd lists Ollama models
+var listOllamaModelsCmd = &cobra.Command{
 	Use:                "models",
 	Short:              "Lists available Ollama models",
 	Long:               `This command lists Ollama models`,
 	Example:            "list models",
 	FParseErrWhitelist: struct{ UnknownFlags bool }{UnknownFlags: false},
 	Run: func(cmd *cobra.Command, args []string) {
-		models, err := u.ListModels(addr)
+		models, err := u.ListOllamaModels(addr)
 		if err != nil {
 			u.LogErrorAndExit(err)
 		}
@@ -34,7 +34,7 @@ var listModelsCmd = &cobra.Command{
 			modelList.WriteString("No models available.\n")
 		} else {
 			for _, model := range models {
-				modelList.WriteString(fmt.Sprintf("- %s\n", model))
+				fmt.Fprintf(&modelList, "- %s\n", model)
 			}
 		}
 
@@ -52,8 +52,43 @@ var listModelsCmd = &cobra.Command{
 	},
 }
 
+// listClaudeModelsCmd lists available Claude models via the Claude Code CLI
+var listClaudeModelsCmd = &cobra.Command{
+	Use:     "claude-models",
+	Short:   "Lists available Claude models",
+	Long:    `This command lists Claude models available through the Claude Code CLI`,
+	Example: "list claude-models",
+	Run: func(cmd *cobra.Command, args []string) {
+		claudeModels := []string{
+			"claude-sonnet-4-20250514",
+			"claude-haiku-4-5-20251001",
+			"claude-opus-4-20250514",
+		}
+
+		var modelList strings.Builder
+		modelList.WriteString("### Available Claude Models\n\n")
+
+		for _, model := range claudeModels {
+			fmt.Fprintf(&modelList, "- %s\n", model)
+		}
+
+		renderer, err := glamour.NewTermRenderer(glamour.WithAutoStyle())
+		if err != nil {
+			u.LogErrorAndExit(fmt.Errorf("error creating markdown renderer: %v", err))
+		}
+
+		rendered, err := renderer.Render(modelList.String())
+		if err != nil {
+			u.LogErrorAndExit(fmt.Errorf("error rendering markdown: %v", err))
+		}
+
+		fmt.Print(rendered)
+	},
+}
+
 func init() {
-	listModelsCmd.Flags().StringVarP(&addr, "address", "a", "http://localhost:11434", "IP Address and port to use for the LLM model (ex: http://localhost:11434)")
-	listCmd.AddCommand(listModelsCmd)
-	listModelsCmd.DisableFlagParsing = false
+	listOllamaModelsCmd.Flags().StringVarP(&addr, "address", "a", "http://localhost:11434", "IP Address and port to use for the LLM model (ex: http://localhost:11434)")
+	listCmd.AddCommand(listOllamaModelsCmd)
+	listCmd.AddCommand(listClaudeModelsCmd)
+	listOllamaModelsCmd.DisableFlagParsing = false
 }

--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -43,9 +43,15 @@ func Analyze(cmd *cobra.Command, args []string) {
 		os.Exit(0)
 	}
 
-	// Validate that the specified model exists in Ollama
-	if err := internal.ValidateModel(model, addr); err != nil {
-		u.LogErrorAndExit(err)
+	// Validate that the specified model exists
+	if internal.IsClaudeModel(model) {
+		if err := internal.ValidateClaudeModel(model); err != nil {
+			u.LogErrorAndExit(err)
+		}
+	} else {
+		if err := internal.ValidateOllamaModel(model, addr); err != nil {
+			u.LogErrorAndExit(err)
+		}
 	}
 
 	// Proceed with the main logic if all required flags are set

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 // Copyright (c) RoseSecurity
 // SPDX-License-Identifier: Apache-2.0
 
+// Package cmd provides the CLI commands for Kuzco.
 package cmd
 
 import (
@@ -48,15 +49,21 @@ func runAnalyzer(cmd *cobra.Command, args []string) {
 		if err != nil {
 			u.LogErrorAndExit(err)
 		}
-		cmd.Help() // Print help to explain the required flags
+		_ = cmd.Help() // Print help to explain the required flags
 		return
 	}
 
-	// Validate that the specified model exists in Ollama
-	if err := internal.ValidateModel(model, addr); err != nil {
-		u.LogErrorAndExit(err)
+	// Validate that the specified model exists
+	if internal.IsClaudeModel(model) {
+		if err := internal.ValidateClaudeModel(model); err != nil {
+			u.LogErrorAndExit(err)
+		}
+	} else {
+		if err := internal.ValidateOllamaModel(model, addr); err != nil {
+			u.LogErrorAndExit(err)
+		}
 	}
-	cmd.Help()
+	_ = cmd.Help()
 }
 
 func Execute() {

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -22,12 +22,9 @@ func TestLatestRelease(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(mockData)
+		_, _ = w.Write(mockData)
 	}))
 	defer server.Close()
-
-	originalURL := "https://api.github.com/repos/RoseSecurity/Kuzco/releases/latest"
-	defer func() { originalURL = originalURL }() // Reset after test
 
 	resp, err := http.Get(server.URL)
 	assert.NoError(t, err)

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Run(filePath, tool, model, prompt, addr string) error {
-	if !(strings.HasSuffix(filePath, ".tf") || strings.HasSuffix(filePath, ".tofu")) {
+	if !strings.HasSuffix(filePath, ".tf") && !strings.HasSuffix(filePath, ".tofu") {
 		return fmt.Errorf("the provided file must have a .tf or .tofu extension")
 	}
 

--- a/internal/claude.go
+++ b/internal/claude.go
@@ -1,0 +1,129 @@
+// Copyright (c) RoseSecurity
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/mattn/go-colorable"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// validClaudeModelPrefixes contains the known valid Claude model prefixes.
+var validClaudeModelPrefixes = []string{
+	"claude-sonnet-",
+	"claude-haiku-",
+	"claude-opus-",
+}
+
+// IsClaudeModel returns true if the model name indicates Claude Code should be used.
+func IsClaudeModel(model string) bool {
+	return strings.HasPrefix(model, "claude")
+}
+
+// ValidateClaudeModel checks if the specified model matches a known Claude model prefix.
+func ValidateClaudeModel(model string) error {
+	for _, prefix := range validClaudeModelPrefixes {
+		if strings.HasPrefix(model, prefix) {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown Claude model '%s'. Valid model prefixes: %v", model, validClaudeModelPrefixes)
+}
+
+// GetClaudeRecommendations generates recommendations using Claude Code's CLI.
+func GetClaudeRecommendations(resourceType string, unusedAttrs []string, tool string, prompt string) (string, error) {
+	if err := validateClaudeInstalled(); err != nil {
+		return "", err
+	}
+
+	formattedPrompt := buildClaudePrompt(resourceType, unusedAttrs, tool, prompt)
+	return execClaude(formattedPrompt)
+}
+
+// GetClaudeFix sends a diagnostic prompt to Claude Code for fixing configuration errors.
+func GetClaudeFix(prompt string) (string, error) {
+	if err := validateClaudeInstalled(); err != nil {
+		return "", err
+	}
+
+	return execClaude(prompt)
+}
+
+func validateClaudeInstalled() error {
+	_, err := exec.LookPath("claude")
+	if err != nil {
+		return fmt.Errorf("claude CLI not found in PATH. Install Claude Code: https://docs.anthropic.com/en/docs/claude-code")
+	}
+	return nil
+}
+
+func buildClaudePrompt(resourceType string, unusedAttrs []string, tool string, userPrompt string) string {
+	tool = cases.Title(language.English, cases.NoLower).String(tool)
+
+	if userPrompt != "" {
+		return fmt.Sprintf(`Unused attributes for '%s' resource '%s': %v
+
+'%s'
+
+Example output:
+resource "type" "name" {
+  # Enables feature X for improved security
+  attribute1 = value1
+
+  # Optimizes performance by setting Y
+  attribute2 = value2
+}`, tool, resourceType, unusedAttrs, userPrompt)
+	}
+
+	return fmt.Sprintf(`Unused attributes for '%s' resource '%s': %v
+
+For each attribute that should be enabled:
+1. Recommend it as Terraform code
+2. Add a brief comment explaining its purpose
+3. Format as a resource block with comments above uncommented parameters
+
+Example output:
+resource "type" "name" {
+  # Enables feature X for improved security
+  attribute1 = value1
+
+  # Optimizes performance by setting Y
+  attribute2 = value2
+}`, tool, resourceType, unusedAttrs)
+}
+
+func execClaude(prompt string) (string, error) {
+	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	_ = s.Color("magenta")
+	s.Writer = colorable.NewColorableStdout()
+	s.Suffix = " Pull the lever, Kronk!"
+	fmt.Printf("%s%s%s ", ColorBold+ColorGreen, s.Suffix, ColorReset)
+	s.Start()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "claude", "--output-format", "text")
+	cmd.Stdin = strings.NewReader(prompt)
+	output, err := cmd.CombinedOutput()
+
+	s.Stop()
+	fmt.Println()
+
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("claude command timed out after 2 minutes")
+		}
+		return "", fmt.Errorf("error executing claude: %v\n%s", err, string(output))
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}

--- a/internal/dry_run.go
+++ b/internal/dry_run.go
@@ -12,7 +12,7 @@ import (
 
 // DryRun checks the provided file for unused attributes based on a provider schema.
 func DryRun(filePath, tool string) ([]string, error) {
-	if !(strings.HasSuffix(filePath, ".tf") || strings.HasSuffix(filePath, ".tofu")) {
+	if !strings.HasSuffix(filePath, ".tf") && !strings.HasSuffix(filePath, ".tofu") {
 		return nil, fmt.Errorf("the provided file must have a .tf or .tofu extension")
 	}
 

--- a/internal/llm.go
+++ b/internal/llm.go
@@ -3,154 +3,25 @@
 
 package internal
 
-import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"time"
-
-	"github.com/briandowns/spinner"
-	"github.com/mattn/go-colorable"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-)
-
-// ANSI color codes
+// ANSI color codes shared across LLM backends
 const (
 	ColorReset = "\033[0m"
 	ColorGreen = "\033[32m"
 	ColorBold  = "\033[1m"
 )
 
-// LlamaRequest represents a request to the Llama API
-type LlamaRequest struct {
-	Model  string `json:"model"`
-	Prompt string `json:"prompt"`
-	Stream bool   `json:"stream"`
-}
-
-// LlamaResponse represents a response from the Llama API
-type LlamaResponse struct {
-	Recommendations string `json:"response"`
-}
-
-// Model represents the structure of a model in the response
-type Model struct {
-	Name string `json:"name"`
-}
-
-// ModelsResponse represents the structure of the response from /api/tags
-type ModelsResponse struct {
-	Models []Model `json:"models"`
-}
-
-// GetRecommendations generates recommendations based on unused attributes and a model.
+// GetRecommendations routes to the appropriate LLM backend based on the model name.
 func GetRecommendations(resourceType string, unusedAttrs []string, model string, tool string, prompt string, addr string) (string, error) {
-	tool = cases.Title(language.English, cases.NoLower).String(tool)
-	var formattedPrompt string
-	if prompt == "" {
-		formattedPrompt = fmt.Sprintf(`Unused attributes for '%s' resource '%s': %v
-
-For each attribute that should be enabled:
-1. Recommend it as Terraform code
-2. Add a brief comment explaining its purpose
-3. Format as a resource block with comments above uncommented parameters
-
-Example output:
-resource "type" "name" {
-  # Enables feature X for improved security
-  attribute1 = value1
-
-  # Optimizes performance by setting Y
-  attribute2 = value2
-}`, tool, resourceType, unusedAttrs)
-	} else {
-		formattedPrompt = fmt.Sprintf(`Unused attributes for '%s' resource '%s': %v
-
-'%s'
-
-Example output:
-resource "type" "name" {
-  # Enables feature X for improved security
-  attribute1 = value1
-
-  # Optimizes performance by setting Y
-  attribute2 = value2
-}`, tool, resourceType, unusedAttrs, prompt)
+	if IsClaudeModel(model) {
+		return GetClaudeRecommendations(resourceType, unusedAttrs, tool, prompt)
 	}
-
-	requestBody := LlamaRequest{
-		Model:  model,
-		Prompt: formattedPrompt,
-		Stream: false,
-	}
-
-	jsonData, err := json.Marshal(requestBody)
-	if err != nil {
-		return "", fmt.Errorf("error marshaling request: %v", err)
-	}
-
-	// Initialize and start the spinner
-	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
-	s.Color("magenta")
-	s.Writer = colorable.NewColorableStdout() // Ensure colors are supported on Windows
-	s.Suffix = " Pull the lever, Kronk!"
-	fmt.Printf("%s%s%s ", ColorBold+ColorGreen, s.Suffix, ColorReset)
-	s.Start()
-
-	// Make the HTTP request
-	resp, err := http.Post(fmt.Sprintf("%s/api/generate", addr), "application/json", bytes.NewBuffer(jsonData))
-	if err != nil {
-		s.Stop()
-		fmt.Println()
-		return "", fmt.Errorf("error making request to API: %v", err)
-	}
-	defer resp.Body.Close()
-
-	// Stop the spinner after the request is done
-	s.Stop()
-	fmt.Println()
-
-	// Read and decode the response
-	var llamaResp LlamaResponse
-	if err := json.NewDecoder(resp.Body).Decode(&llamaResp); err != nil {
-		return "", fmt.Errorf("error decoding response: %v", err)
-	}
-
-	return llamaResp.Recommendations, nil
+	return GetOllamaRecommendations(resourceType, unusedAttrs, model, tool, prompt, addr)
 }
 
-// ValidateModel checks if the specified model exists in Ollama
-func ValidateModel(model, addr string) error {
-	// Get a list of available models from Ollama
-	resp, err := http.Get(fmt.Sprintf("%s/api/tags", addr))
-	if err != nil {
-		return fmt.Errorf("error fetching models from Ollama: %v", err)
+// GetFix routes fix prompts to the appropriate LLM backend based on the model name.
+func GetFix(prompt, model, addr string) (string, error) {
+	if IsClaudeModel(model) {
+		return GetClaudeFix(prompt)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to retrieve models: status code %d", resp.StatusCode)
-	}
-
-	// Parse the response body into ModelsResponse
-	var modelsResp ModelsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&modelsResp); err != nil {
-		return fmt.Errorf("error decoding models response: %v", err)
-	}
-
-	// Check if the requested model is in the list of models
-	for _, availableModel := range modelsResp.Models {
-		if availableModel.Name == model {
-			return nil
-		}
-	}
-
-	// If the model is not found, return an error and list available models
-	var availableModelNames []string
-	for _, availableModel := range modelsResp.Models {
-		availableModelNames = append(availableModelNames, availableModel.Name)
-	}
-	return fmt.Errorf("model '%s' not found. Available models: %v", model, availableModelNames)
+	return GetOllamaFix(prompt, model, addr)
 }

--- a/internal/ollama.go
+++ b/internal/ollama.go
@@ -1,0 +1,164 @@
+// Copyright (c) RoseSecurity
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	u "github.com/RoseSecurity/kuzco/pkg/utils"
+	"github.com/briandowns/spinner"
+	"github.com/mattn/go-colorable"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// OllamaRequest represents a request to the Ollama API
+type OllamaRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	Stream bool   `json:"stream"`
+}
+
+// OllamaResponse represents a response from the Ollama API
+type OllamaResponse struct {
+	Recommendations string `json:"response"`
+}
+
+// sendOllamaRequest sends a prompt to the Ollama API and returns the response text.
+func sendOllamaRequest(prompt, model, addr string) (string, error) {
+	requestBody := OllamaRequest{
+		Model:  model,
+		Prompt: prompt,
+		Stream: false,
+	}
+
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	// Initialize and start the spinner
+	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	_ = s.Color("magenta")
+	s.Writer = colorable.NewColorableStdout() // Ensure colors are supported on Windows
+	s.Suffix = " Pull the lever, Kronk!"
+	fmt.Printf("%s%s%s ", ColorBold+ColorGreen, s.Suffix, ColorReset)
+	s.Start()
+
+	// Make the HTTP request
+	resp, err := http.Post(fmt.Sprintf("%s/api/generate", addr), "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		s.Stop()
+		fmt.Println()
+		return "", fmt.Errorf("error making request to Ollama API: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Stop the spinner after the request is done
+	s.Stop()
+	fmt.Println()
+
+	// Check HTTP status code
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("Ollama API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	// Read and decode the response
+	var ollamaResp OllamaResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ollamaResp); err != nil {
+		return "", fmt.Errorf("error decoding response: %v", err)
+	}
+
+	if strings.TrimSpace(ollamaResp.Recommendations) == "" {
+		return "", fmt.Errorf("Ollama returned an empty response")
+	}
+
+	return ollamaResp.Recommendations, nil
+}
+
+// GetOllamaRecommendations generates recommendations using Ollama's API.
+func GetOllamaRecommendations(resourceType string, unusedAttrs []string, model string, tool string, prompt string, addr string) (string, error) {
+	tool = cases.Title(language.English, cases.NoLower).String(tool)
+	var formattedPrompt string
+	if prompt == "" {
+		formattedPrompt = fmt.Sprintf(`Unused attributes for '%s' resource '%s': %v
+
+For each attribute that should be enabled:
+1. Recommend it as Terraform code
+2. Add a brief comment explaining its purpose
+3. Format as a resource block with comments above uncommented parameters
+
+Example output:
+resource "type" "name" {
+  # Enables feature X for improved security
+  attribute1 = value1
+
+  # Optimizes performance by setting Y
+  attribute2 = value2
+}`, tool, resourceType, unusedAttrs)
+	} else {
+		formattedPrompt = fmt.Sprintf(`Unused attributes for '%s' resource '%s': %v
+
+'%s'
+
+Example output:
+resource "type" "name" {
+  # Enables feature X for improved security
+  attribute1 = value1
+
+  # Optimizes performance by setting Y
+  attribute2 = value2
+}`, tool, resourceType, unusedAttrs, prompt)
+	}
+
+	return sendOllamaRequest(formattedPrompt, model, addr)
+}
+
+// GetOllamaFix sends a pre-formatted diagnostic prompt to Ollama for fixing configuration errors.
+func GetOllamaFix(prompt, model, addr string) (string, error) {
+	return sendOllamaRequest(prompt, model, addr)
+}
+
+// ValidateOllamaModel checks if the specified model exists in Ollama
+func ValidateOllamaModel(model, addr string) error {
+	// Get a list of available models from Ollama
+	resp, err := http.Get(fmt.Sprintf("%s/api/tags", addr))
+	if err != nil {
+		return fmt.Errorf("error fetching models from Ollama: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to retrieve models: status code %d", resp.StatusCode)
+	}
+
+	// Parse the response body
+	var modelsResp struct {
+		Models []u.OllamaModel `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&modelsResp); err != nil {
+		return fmt.Errorf("error decoding models response: %v", err)
+	}
+
+	// Check if the requested model is in the list of models
+	for _, availableModel := range modelsResp.Models {
+		if availableModel.Name == model {
+			return nil
+		}
+	}
+
+	// If the model is not found, return an error and list available models
+	var availableModelNames []string
+	for _, availableModel := range modelsResp.Models {
+		availableModelNames = append(availableModelNames, availableModel.Name)
+	}
+	return fmt.Errorf("model '%s' not found. Available models: %v", model, availableModelNames)
+}

--- a/pkg/utils/list_models.go
+++ b/pkg/utils/list_models.go
@@ -10,12 +10,13 @@ import (
 	"net/url"
 )
 
-type Model struct {
+// OllamaModel represents the structure of an Ollama model
+type OllamaModel struct {
 	Name string `json:"name"`
 }
 
-// ListModels lists available models from Ollama
-func ListModels(addr string) ([]string, error) {
+// ListOllamaModels lists available models from Ollama
+func ListOllamaModels(addr string) ([]string, error) {
 	if _, err := url.Parse(addr); err != nil {
 		return nil, fmt.Errorf("invalid address provided: %v", err)
 	}
@@ -31,7 +32,7 @@ func ListModels(addr string) ([]string, error) {
 	}
 
 	var result struct {
-		Models []Model `json:"models"`
+		Models []OllamaModel `json:"models"`
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -26,9 +26,10 @@ func LogErrorAndExit(err error) {
 		// Find the executed command's exit code from the error
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
-			exitCode := exitError.ExitCode()
-			os.Exit(exitCode)
+			os.Exit(exitError.ExitCode())
 		}
+
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
## What and Why

Add support for using Claude Code CLI alongside Ollama for generating infrastructure recommendations and fixes.

Changes:
- Add claude.go with Claude Code CLI integration via stdin/stdout
- Refactor llm.go to route requests based on model prefix
- Split Ollama logic into dedicated ollama.go file
- Add `list claude-models` command to show available Claude models
- Rename ListModels to ListOllamaModels for clarity
- Update model validation to support both backends
- Migrate golangci-lint config to v2 format
- Fix various linter warnings (error handling, unused variables)

Claude models are detected by the "claude-" prefix and require the claude CLI to be installed. Ollama remains the default backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Claude Code as an LLM backend alongside Ollama
  * Model operations now intelligently route to the appropriate backend based on model type

* **Improvements**
  * Updated command descriptions to reference "LLM models" instead of provider-specific terminology
  * Enhanced list command to support viewing models from multiple backends

* **Chores**
  * Updated linting configuration for improved code quality checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->