### PR TITLE
feat: add --init-backend flag to control terraform/tofu init

### DIFF
--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -25,6 +25,7 @@ func init() {
 	recommendCmd.Flags().StringVarP(&model, "model", "m", "llama3.2", "LLM model to use for generating recommendations")
 	recommendCmd.Flags().StringVarP(&prompt, "prompt", "p", "", "User prompt for guiding the response format of the LLM model")
 	recommendCmd.Flags().StringVarP(&addr, "address", "a", "http://localhost:11434", "IP Address and port to use for the LLM model (ex: http://localhost:11434)")
+	recommendCmd.Flags().BoolVar(&initBackend, "init-backend", false, "Initialize the backend during terraform/tofu init")
 	recommendCmd.Flags().BoolVar(&dryrun, "dry-run", false, "Test unused parameter functionality")
 	// Hide dry run flag
 	recommendCmd.Flags().Lookup("dry-run").Hidden = true
@@ -34,7 +35,7 @@ func Analyze(cmd *cobra.Command, args []string) {
 	// Run the logic test if the flag is set
 	if dryrun {
 		var unusedAttrs []string
-		unusedAttrs, err := internal.DryRun(filePath, tool)
+		unusedAttrs, err := internal.DryRun(filePath, tool, initBackend)
 		if err != nil {
 			u.LogErrorAndExit(err)
 		} else {
@@ -55,7 +56,7 @@ func Analyze(cmd *cobra.Command, args []string) {
 	}
 
 	// Proceed with the main logic if all required flags are set
-	if err := internal.Run(filePath, tool, model, prompt, addr); err != nil {
+	if err := internal.Run(filePath, tool, model, prompt, addr, initBackend); err != nil {
 		u.LogErrorAndExit(err)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,8 @@ var (
 	model    string
 	prompt   string
 	addr     string
-	dryrun   bool
+	dryrun      bool
+	initBackend bool
 )
 
 var rootCmd = &cobra.Command{

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-func Run(filePath, tool, model, prompt, addr string) error {
+func Run(filePath, tool, model, prompt, addr string, initBackend bool) error {
 	if !strings.HasSuffix(filePath, ".tf") && !strings.HasSuffix(filePath, ".tofu") {
 		return fmt.Errorf("the provided file must have a .tf or .tofu extension")
 	}
@@ -25,12 +25,12 @@ func Run(filePath, tool, model, prompt, addr string) error {
 
 	switch tool {
 	case "terraform":
-		providerSchema, err = ExtractTerraformProviderSchema(dir)
+		providerSchema, err = ExtractTerraformProviderSchema(dir, initBackend)
 		if err != nil {
 			return fmt.Errorf("error extracting Terraform provider schema: %v", err)
 		}
 	case "opentofu":
-		providerSchema, err = ExtractOpenTofuProviderSchema(dir)
+		providerSchema, err = ExtractOpenTofuProviderSchema(dir, initBackend)
 		if err != nil {
 			return fmt.Errorf("error extracting OpenTofu provider schema: %v", err)
 		}

--- a/internal/dry_run.go
+++ b/internal/dry_run.go
@@ -11,7 +11,7 @@ import (
 )
 
 // DryRun checks the provided file for unused attributes based on a provider schema.
-func DryRun(filePath, tool string) ([]string, error) {
+func DryRun(filePath, tool string, initBackend bool) ([]string, error) {
 	if !strings.HasSuffix(filePath, ".tf") && !strings.HasSuffix(filePath, ".tofu") {
 		return nil, fmt.Errorf("the provided file must have a .tf or .tofu extension")
 	}
@@ -27,12 +27,12 @@ func DryRun(filePath, tool string) ([]string, error) {
 
 	switch tool {
 	case "terraform":
-		providerSchema, err = ExtractTerraformProviderSchema(dir)
+		providerSchema, err = ExtractTerraformProviderSchema(dir, initBackend)
 		if err != nil {
 			return nil, fmt.Errorf("error extracting Terraform provider schema: %v", err)
 		}
 	case "opentofu":
-		providerSchema, err = ExtractOpenTofuProviderSchema(dir)
+		providerSchema, err = ExtractOpenTofuProviderSchema(dir, initBackend)
 		if err != nil {
 			return nil, fmt.Errorf("error extracting OpenTofu provider schema: %v", err)
 		}

--- a/internal/opentofu_schema.go
+++ b/internal/opentofu_schema.go
@@ -10,12 +10,16 @@ import (
 	"os/exec"
 )
 
-func ExtractOpenTofuProviderSchema(rootDir string) (ProviderSchema, error) {
+func ExtractOpenTofuProviderSchema(rootDir string, initBackend bool) (ProviderSchema, error) {
 	schema := ProviderSchema{
 		ResourceTypes: make(map[string]map[string]any),
 	}
 
-	initCmd := exec.Command("tofu", "init")
+	initArgs := []string{"init"}
+	if !initBackend {
+		initArgs = append(initArgs, "-backend=false")
+	}
+	initCmd := exec.Command("tofu", initArgs...)
 	initCmd.Dir = rootDir
 	var initStderr bytes.Buffer
 	initCmd.Stderr = &initStderr

--- a/internal/terraform_schema.go
+++ b/internal/terraform_schema.go
@@ -14,13 +14,17 @@ type ProviderSchema struct {
 	ResourceTypes map[string]map[string]any
 }
 
-func ExtractTerraformProviderSchema(rootDir string) (ProviderSchema, error) {
+func ExtractTerraformProviderSchema(rootDir string, initBackend bool) (ProviderSchema, error) {
 	schema := ProviderSchema{
 		ResourceTypes: make(map[string]map[string]any),
 	}
 
 	// Run terraform init first
-	initCmd := exec.Command("terraform", "init")
+	initArgs := []string{"init"}
+	if !initBackend {
+		initArgs = append(initArgs, "-backend=false")
+	}
+	initCmd := exec.Command("terraform", initArgs...)
 	initCmd.Dir = rootDir
 	var initStderr bytes.Buffer
 	initCmd.Stderr = &initStderr


### PR DESCRIPTION
## What and Why

This pull request adds a new `--init-backend` flag to the CLI, allowing users to control whether the backend is initialized during Terraform/OpenTofu operations. The flag is threaded through the codebase, affecting both the main execution path and the dry run functionality. The core logic for running `terraform init` and `tofu init` now conditionally disables backend initialization based on this flag.

**Flag and CLI enhancements:**

* Added a new `--init-backend` boolean flag to the `recommend` command, allowing users to specify whether to initialize the backend during `terraform init` or `tofu init`. The flag defaults to `false`. [[1]](diffhunk://#diff-b9ad7e2cf3a3386f270029fc9deaf51cf2b1d172220a70b59b405a7de9363985R28) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR23)

**Propagation of the new flag:**

* Updated the `Analyze` function and internal logic to pass the `initBackend` flag to both the main execution (`internal.Run`) and dry run (`internal.DryRun`) functions, ensuring consistent behavior throughout the codebase. [[1]](diffhunk://#diff-b9ad7e2cf3a3386f270029fc9deaf51cf2b1d172220a70b59b405a7de9363985L37-R38) [[2]](diffhunk://#diff-b9ad7e2cf3a3386f270029fc9deaf51cf2b1d172220a70b59b405a7de9363985L58-R59) [[3]](diffhunk://#diff-0dd94bc046a3013c7add1c5ca0c46824618dd223cc08eb258e9a1caf143067a9L13-R13) [[4]](diffhunk://#diff-a772e2596bd8fb07a83ddbd44ee83a389d7838246069c7a7973eda1b44ac4aa9L14-R14)

**Backend initialization logic:**

* Modified `ExtractTerraformProviderSchema` and `ExtractOpenTofuProviderSchema` functions to accept the `initBackend` parameter. When `initBackend` is `false`, these functions now run `terraform init -backend=false` or `tofu init -backend=false` to skip backend initialization. [[1]](diffhunk://#diff-0dd94bc046a3013c7add1c5ca0c46824618dd223cc08eb258e9a1caf143067a9L28-R33) [[2]](diffhunk://#diff-a772e2596bd8fb07a83ddbd44ee83a389d7838246069c7a7973eda1b44ac4aa9L30-R35) [[3]](diffhunk://#diff-4f20c828ee92a0c265498c55c0d9069456eb8db112e83cea16066cbf8411140dL13-R22) [[4]](diffhunk://#diff-c7873ff2f61fa812fed90437a41dd0544f7b8343c06f217f87eacae150a84420L17-R27)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--init-backend` flag to the recommend command for controlling backend initialization during analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->